### PR TITLE
Add support to CST816 chips with different register for chip ID

### DIFF
--- a/adafruit_cst8xx.py
+++ b/adafruit_cst8xx.py
@@ -48,6 +48,7 @@ _CST_REG_NUMTOUCHES = const(0x02)
 _CST_REG_TOUCHDATA = const(0x03)
 _CST_REG_SLEEP = const(0xA5)
 _CST_REG_FIRMVERS = const(0xA6)
+_CST_REG_CHIPID_816 = const(0xA7)
 _CST_REG_MODID = const(0xA8)
 _CST_REG_PROJID = const(0xA9)
 _CST_REG_CHIPTYPE = const(0xAA)
@@ -77,14 +78,20 @@ class Adafruit_CST8XX:
 
         chip_data = self._read(_CST_REG_FIRMVERS, 6)  # don't wait for IRQ
         # print("chip_data: {%x}".format(chip_data))
-        fw_version, _, _, chip_type = struct.unpack("<HBBH", chip_data)
-        print("fw_version: {:02X}, chip_type: {:02X}".format(fw_version, chip_type))
-
-        if chip_type not in (_CHIP_ID_CST826,):
-            raise RuntimeError("Did not find CST8XX chip")
-
         if debug:
-            print("Firmware vers %04X" % int(fw_version))
+            fw_version, _, _, chip_type = struct.unpack("<HBBH", chip_data)
+            print("fw_version: {:02X}, chip_type: {:02X}".format(fw_version, chip_type))
+
+        if chip_data[1] in (_CHIP_ID_CST816S, _CHIP_ID_CST816T, _CHIP_ID_CST816D):
+            # this is a CST816x
+            if debug:
+                print("CST816 chip found")
+        elif chip_data[5] in (_CHIP_ID_CST826,):
+            # this is a CST826
+            if debug:
+                print("CST826 chip found")
+        else:
+            raise RuntimeError("Did not find supported CST8XX chip")
 
     @property
     def touched(self) -> int:


### PR DESCRIPTION
I have successfully used the library with a CST816D chips with no other modification than removing the test for the chip_type. For example the `Waveshare esp32 s3 touch lcd 2` uses it as well as a generic ESP32-C3 round display board (that is not in CP yet).
When running, the library reports:
```
fw_version: B600, chip_type: 04
```
But it's the chip ID that's supposed to be `B6`.
I was not able to find a datasheet containing that information, but [the CST816_TouchLib Arduino library](https://github.com/mjdonders/CST816_TouchLib/blob/49abd91083de87a0c34cfa59ac47efac4995fffb/src/CST816Touch.cpp#L26-L28) has these constants. Also [in zephyr's support](https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/input/input_cst816s.c).
```ino
const uint8_t TOUCH_REGISTER_CHIP_ID			= 0xA7;		//chip ID (/model) (1 byte)
const uint8_t TOUCH_REGISTER_PROJ_ID			= 0xA8;		//project number (1 byte)
const uint8_t TOUCH_REGISTER_FW_VERSION			= 0xA9;		//firmware version
```
So since the rest of the registers used seem to work the same, this PR just tries to find a chip ID to validate that it's a valid chip.